### PR TITLE
Rdiscrowd 166 completed task api

### DIFF
--- a/pybossa/pybossa/api/completed_task.py
+++ b/pybossa/pybossa/api/completed_task.py
@@ -22,7 +22,7 @@ This package adds GET methods for:
     * tasks
 
 """
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, MethodNotAllowed
 from flask import request
 from pybossa.model.task import Task
 #from pybossa.model.completed_task import CompletedTask
@@ -35,7 +35,7 @@ class CompletedTaskAPI(TaskAPI):
 
     __class__ = Task
     #__class__ = CompletedTask
-    reserved_keys = set(['id', 'created', 'state', 'exported'])
+    reserved_keys = set(['id', 'created', 'state'])
     
     def _forbidden_attributes(self, data):
         for key in data.keys():
@@ -46,9 +46,6 @@ class CompletedTaskAPI(TaskAPI):
         raise MethodNotAllowed(valid_methods=['GET'])
 
     def delete(self, oid=None):
-        raise MethodNotAllowed(valid_methods=['GET'])
-
-    def put(self, oid=None):
         raise MethodNotAllowed(valid_methods=['GET'])
 
     def is_admin_api_key(self):

--- a/pybossa/pybossa/api/completed_task.py
+++ b/pybossa/pybossa/api/completed_task.py
@@ -43,10 +43,10 @@ class CompletedTaskAPI(TaskAPI):
                 raise BadRequest("Reserved keys in payload")
 
     def post(self):
-        raise MethodNotAllowed(valid_methods=['GET'])
+        raise MethodNotAllowed(valid_methods=['GET','PUT'])
 
     def delete(self, oid=None):
-        raise MethodNotAllowed(valid_methods=['GET'])
+        raise MethodNotAllowed(valid_methods=['GET','PUT'])
 
     def is_admin_api_key(self):
         """Check if api_key passed is of admin_user"""

--- a/pybossa/pybossa/api/completed_task_run.py
+++ b/pybossa/pybossa/api/completed_task_run.py
@@ -26,7 +26,7 @@ from flask import request
 from flask.ext.login import current_user
 from pybossa.model.task_run import TaskRun
 from pybossa.model.completed_task_run import CompletedTaskRun
-from werkzeug.exceptions import Forbidden, BadRequest
+from werkzeug.exceptions import Forbidden, BadRequest, MethodNotAllowed
 
 from task_run import TaskRunAPI
 from pybossa.util import get_user_id_or_ip


### PR DESCRIPTION
- Allow put request for /completedtask api so that task can  be marked as exported=True after export
- Include missing import of MethodNotAllowed exception
- Remove exported from reserved keys so that it can be updated with put request