### PR TITLE
File upload

### DIFF
--- a/pybossa/pybossa/api/api_base.py
+++ b/pybossa/pybossa/api/api_base.py
@@ -179,8 +179,8 @@ class APIBase(MethodView):
         try:
             self.valid_args()
             data = json.loads(request.data)
-            self._preprocess_post_data(data)
             self._forbidden_attributes(data)
+            self._preprocess_post_data(data)
             inst = self._create_instance_from_request(data)
             repo = repos[self.__class__.__name__]['repo']
             save_func = repos[self.__class__.__name__]['save']

--- a/pybossa/pybossa/api/api_base.py
+++ b/pybossa/pybossa/api/api_base.py
@@ -179,6 +179,7 @@ class APIBase(MethodView):
         try:
             self.valid_args()
             data = json.loads(request.data)
+            self._preprocess_post_data(data)
             self._forbidden_attributes(data)
             inst = self._create_instance_from_request(data)
             repo = repos[self.__class__.__name__]['repo']
@@ -191,6 +192,11 @@ class APIBase(MethodView):
                 e,
                 target=self.__class__.__name__.lower(),
                 action='POST')
+
+    def _preprocess_post_data(self, data):
+        """Method to be overriden by inheriting classes that will
+        perform preprocessing on the POST data"""
+        pass
 
     def _create_instance_from_request(self, data):
         data = self.hateoas.remove_links(data)

--- a/pybossa/pybossa/api/api_base.py
+++ b/pybossa/pybossa/api/api_base.py
@@ -178,7 +178,7 @@ class APIBase(MethodView):
         """
         try:
             self.valid_args()
-            data = json.loads(request.data)
+            data = self._parse_request_data()
             self._forbidden_attributes(data)
             self._preprocess_post_data(data)
             inst = self._create_instance_from_request(data)
@@ -192,6 +192,13 @@ class APIBase(MethodView):
                 e,
                 target=self.__class__.__name__.lower(),
                 action='POST')
+
+    def _parse_request_data(self):
+        if 'request_json' in request.form:
+            data = json.loads(request.form['request_json'])
+        else:
+            data = json.loads(request.data)
+        return data
 
     def _preprocess_post_data(self, data):
         """Method to be overriden by inheriting classes that will

--- a/pybossa/pybossa/api/task_run.py
+++ b/pybossa/pybossa/api/task_run.py
@@ -26,13 +26,13 @@ from flask import request
 from flask.ext.login import current_user
 from pybossa.model.task_run import TaskRun
 from werkzeug.exceptions import Forbidden, BadRequest
-from werkzeug import secure_filename
 import os
 
 from api_base import APIBase
 from pybossa.util import get_user_id_or_ip
 from pybossa.core import task_repo, sentinel
-from pybossa.uploader.s3_uploader import s3_upload_from_string, s3_upload
+from pybossa.uploader.s3_uploader import s3_upload_from_string
+from pybossa.uploader.s3_uploader import s3_upload_file_obj
 
 
 class TaskRunAPI(APIBase):
@@ -54,11 +54,17 @@ class TaskRunAPI(APIBase):
             if key.endswith('__upload_url'):
                 filename = info[key]['filename']
                 self._validate_filename(filename)
-                filename = secure_filename(filename)
                 content = info[key]['content']
                 s3_url = s3_upload_from_string(content, filename,
-                                               upload_dir=path)
+                                               directory=path)
                 info[key] = s3_url
+        for key in request.files:
+            if not key.endswith('__upload_url'):
+                raise BadRequest("File upload field should end in __upload_url")
+            file_obj = request.files[key]
+            self._validate_filename(file_obj.filename)
+            s3_url = s3_upload_file_obj(file_obj, directory=path)
+            info[key] = s3_url
 
     def _validate_filename(self, filename):
         extension = os.path.splitext(filename)[1]

--- a/pybossa/pybossa/api/task_run.py
+++ b/pybossa/pybossa/api/task_run.py
@@ -27,6 +27,7 @@ from flask.ext.login import current_user
 from pybossa.model.task_run import TaskRun
 from werkzeug.exceptions import Forbidden, BadRequest
 from werkzeug import secure_filename
+import os
 
 from api_base import APIBase
 from pybossa.util import get_user_id_or_ip
@@ -46,10 +47,9 @@ class TaskRunAPI(APIBase):
     def _preprocess_post_data(self, data):
         task_id = data['task_id']
         project_id = data['project_id']
-        user_id = data['user_id']
+        user_id = current_user.id
         info = data['info']
-        path = "{0}/{1}/{2}/{3}".format('dev', project_id, task_id, user_id)
-        print "hic sunt leones"
+        path = "{0}/{1}/{2}".format(project_id, task_id, user_id)
         for key in info:
             if key.endswith('__upload_url'):
                 filename = info[key]['filename']
@@ -58,7 +58,7 @@ class TaskRunAPI(APIBase):
                 content = info[key]['content']
                 s3_url = s3_upload_from_string(content, filename,
                                                upload_dir=path)
-                data[key] = s3_url
+                info[key] = s3_url
 
     def _validate_filename(self, filename):
         extension = os.path.splitext(filename)[1]

--- a/pybossa/pybossa/uploader/s3_uploader.py
+++ b/pybossa/pybossa/uploader/s3_uploader.py
@@ -1,0 +1,59 @@
+from uuid import uuid4
+import boto
+import os.path
+from flask import current_app as app
+
+
+# from werkzeug.utils import secure_filename
+
+
+def s3_upload_from_string(string, filename, headers=None, upload_dir=None):
+    if upload_dir is None:
+        upload_dir = ""  # app.config["S3_UPLOAD_DIRECTORY"]
+
+    source_filename = filename  # secure_filename(filename)
+    source_extension = os.path.splitext(source_filename)[1]
+
+    destination_filename = source_filename + source_extension
+
+    # Connect to S3 and upload file.
+    conn = boto.connect_s3(app.config["S3_KEY"], app.config["S3_SECRET"])
+    b = conn.get_bucket(app.config["S3_BUCKET"])
+
+    key = b.new_key("/".join([upload_dir, destination_filename]))
+    key.set_contents_from_string(string, headers=headers)
+    key.set_acl(acl)
+
+    return key.generate_url(0).split('?', 1)[0]
+
+
+def s3_upload(source_file, upload_dir=None):
+    """ Uploads WTForm File Object to Amazon S3
+        Expects following app.config attributes to be set:
+            S3_KEY              :   S3 API Key
+            S3_SECRET           :   S3 Secret Key
+            S3_BUCKET           :   What bucket to upload to
+            S3_UPLOAD_DIRECTORY :   Which S3 Directory.
+        The default sets the access rights on the uploaded file to
+        public-read.  It also generates a unique filename via
+        the uuid4 function combined with the file extension from
+        the source file.
+    """
+
+    if upload_dir is None:
+        upload_dir = app.config["S3_UPLOAD_DIRECTORY"]
+
+    source_filename = filename  # secure_filename(source_file.data.filename)
+    source_extension = os.path.splitext(source_filename)[1]
+
+    destination_filename = uuid4().hex + source_extension
+
+    # Connect to S3 and upload file.
+    conn = boto.connect_s3(app.config["S3_KEY"], app.config["S3_SECRET"])
+    b = conn.get_bucket(app.config["S3_BUCKET"])
+
+    key = b.new_key("/".join([upload_dir, destination_filename]))
+    key.set_contents_from_string(source_file.data.read())
+    key.set_acl(acl)
+
+    return destination_filename

--- a/pybossa/pybossa/uploader/s3_uploader.py
+++ b/pybossa/pybossa/uploader/s3_uploader.py
@@ -5,6 +5,7 @@ import magic
 from tempfile import NamedTemporaryFile
 import os
 from werkzeug.exceptions import BadRequest
+import re
 
 
 allowed_mime_types = ['application/pdf',
@@ -22,6 +23,12 @@ def check_type(filename):
     mime_type = magic.from_file(filename, mime=True)
     if mime_type not in allowed_mime_types:
         raise BadRequest("File Type Not Supported")
+
+
+def validate_directory(directory_name):
+    invalid_chars = "[^\w\/]"
+    if re.search(invalid_chars, directory_name):
+        raise RuntimeError("Invalid character in directory name")
 
 
 def tmp_file_from_string(string):
@@ -78,6 +85,7 @@ def s3_upload_file(fp, filename, headers, directory=""):
         upload_dir = "/".join([app.config["S3_UPLOAD_DIRECTORY"], directory])
     else:
         upload_dir = app.config["S3_UPLOAD_DIRECTORY"]
+    validate_directory(upload_dir)
 
     filename = secure_filename(filename)
     conn = boto.connect_s3(app.config["S3_KEY"], app.config["S3_SECRET"])

--- a/pybossa/pybossa/uploader/s3_uploader.py
+++ b/pybossa/pybossa/uploader/s3_uploader.py
@@ -1,47 +1,89 @@
 import boto
 from flask import current_app as app
 from werkzeug.utils import secure_filename
+import magic
+from tempfile import NamedTemporaryFile
+import os
+from werkzeug.exceptions import BadRequest
+
+
+allowed_mime_types = ['application/pdf',
+                      'text/csv',
+                      'text/richtext',
+                      'text/tab-separated-values',
+                      'text/xml',
+                      'text/plain',
+                      'application/oda',
+                      'text/html',
+                      'application/xml']
+
+
+def check_type(filename):
+    mime_type = magic.from_file(filename, mime=True)
+    if mime_type not in allowed_mime_types:
+        raise BadRequest("File Type Not Supported")
+
+
+def tmp_file_from_string(string):
+    """
+    Create a temporary file with the given content
+    """
+    tmp_file = NamedTemporaryFile(delete=False)
+    try:
+        with open(tmp_file.name, "w") as fp:
+            fp.write(string)
+    except Exception as e:
+        os.unlink(tmp_file.name)
+        raise e
+    return tmp_file
 
 
 def s3_upload_from_string(string, filename, headers=None, directory=""):
+    """
+    Upload a string to s3
+    """
+    tmp_file = tmp_file_from_string(string)
+    return s3_upload_tmp_file(tmp_file, filename, headers, directory)
 
+
+def s3_upload_file_storage(source_file, directory=""):
+    """
+    Upload a werzkeug FileStorage content to s3
+    """
+    filename = source_file.filename
+    headers = {"Content-Type": source_file.content_type}
+    tmp_file = NamedTemporaryFile(delete=False)
+    source_file.save(tmp_file.name)
+    return s3_upload_tmp_file(tmp_file, filename, headers, directory)
+
+
+def s3_upload_tmp_file(tmp_file, filename, headers, directory=""):
+    """
+    Upload the content of a temporary file to s3 and delete the file
+    """
+    try:
+        check_type(tmp_file.name)
+        with open(tmp_file.name) as fp:
+            url = s3_upload_file(fp, filename, headers, directory)
+    finally:
+        os.unlink(tmp_file.name)
+    return url
+
+
+def s3_upload_file(fp, filename, headers, directory=""):
+    """
+    Upload a file-type object to s3
+    """
     if directory:
         upload_dir = "/".join([app.config["S3_UPLOAD_DIRECTORY"], directory])
     else:
         upload_dir = app.config["S3_UPLOAD_DIRECTORY"]
 
     filename = secure_filename(filename)
-    # Connect to S3 and upload file.
     conn = boto.connect_s3(app.config["S3_KEY"], app.config["S3_SECRET"])
-    b = conn.get_bucket(app.config["S3_BUCKET"])
+    bucket = conn.get_bucket(app.config["S3_BUCKET"])
 
-    key = b.new_key("/".join([upload_dir, filename]))
-    key.set_contents_from_string(string, headers=headers)
-
-    return key.generate_url(0).split('?', 1)[0]
-
-
-def s3_upload_file_obj(source_file, directory=""):
-    """ Uploads FileStorage Object to Amazon S3
-        Expects following app.config attributes to be set:
-            S3_KEY              :   S3 API Key
-            S3_SECRET           :   S3 Secret Key
-            S3_BUCKET           :   What bucket to upload to
-            S3_UPLOAD_DIRECTORY :   Which S3 Directory.
-    """
-
-    if directory:
-        upload_dir = "/".join([app.config["S3_UPLOAD_DIRECTORY"], directory])
-    else:
-        upload_dir = app.config["S3_UPLOAD_DIRECTORY"]
-
-    filename = secure_filename(source_file.filename)
-    headers = {"Content-Type": source_file.content_type}
-    # Connect to S3 and upload file.
-    conn = boto.connect_s3(app.config["S3_KEY"], app.config["S3_SECRET"])
-    b = conn.get_bucket(app.config["S3_BUCKET"])
-
-    key = b.new_key("/".join([upload_dir, filename]))
-    key.set_contents_from_file(source_file.stream, headers=headers)
+    key = bucket.new_key("/".join([upload_dir, filename]))
+    key.set_contents_from_file(fp, headers=headers)
 
     return key.generate_url(0).split('?', 1)[0]

--- a/pybossa/pybossa/uploader/s3_uploader.py
+++ b/pybossa/pybossa/uploader/s3_uploader.py
@@ -6,7 +6,7 @@ from werkzeug.utils import secure_filename
 def s3_upload_from_string(string, filename, headers=None, directory=""):
 
     if directory:
-        upload_dir = "/".join(app.config["S3_UPLOAD_DIRECTORY", directory])
+        upload_dir = "/".join([app.config["S3_UPLOAD_DIRECTORY"], directory])
     else:
         upload_dir = app.config["S3_UPLOAD_DIRECTORY"]
 
@@ -31,12 +31,12 @@ def s3_upload_file_obj(source_file, directory=""):
     """
 
     if directory:
-        upload_dir = "/".join(app.config["S3_UPLOAD_DIRECTORY", directory])
+        upload_dir = "/".join([app.config["S3_UPLOAD_DIRECTORY"], directory])
     else:
         upload_dir = app.config["S3_UPLOAD_DIRECTORY"]
 
     filename = secure_filename(source_file.filename)
-    headers = {"Content-Type": filename.content_type}
+    headers = {"Content-Type": source_file.content_type}
     # Connect to S3 and upload file.
     conn = boto.connect_s3(app.config["S3_KEY"], app.config["S3_SECRET"])
     b = conn.get_bucket(app.config["S3_BUCKET"])

--- a/pybossa/pybossa/uploader/s3_uploader.py
+++ b/pybossa/pybossa/uploader/s3_uploader.py
@@ -1,16 +1,16 @@
-from uuid import uuid4
 import boto
-import os.path
 from flask import current_app as app
+from werkzeug.utils import secure_filename
 
 
-# from werkzeug.utils import secure_filename
+def s3_upload_from_string(string, filename, headers=None, directory=""):
 
-
-def s3_upload_from_string(string, filename, headers=None, upload_dir=None):
-    if upload_dir is None:
+    if directory:
+        upload_dir = "/".join(app.config["S3_UPLOAD_DIRECTORY", directory])
+    else:
         upload_dir = app.config["S3_UPLOAD_DIRECTORY"]
 
+    filename = secure_filename(filename)
     # Connect to S3 and upload file.
     conn = boto.connect_s3(app.config["S3_KEY"], app.config["S3_SECRET"])
     b = conn.get_bucket(app.config["S3_BUCKET"])
@@ -21,8 +21,8 @@ def s3_upload_from_string(string, filename, headers=None, upload_dir=None):
     return key.generate_url(0).split('?', 1)[0]
 
 
-def s3_upload(source_file, upload_dir=None):
-    """ Uploads WTForm File Object to Amazon S3
+def s3_upload_file_obj(source_file, directory=""):
+    """ Uploads FileStorage Object to Amazon S3
         Expects following app.config attributes to be set:
             S3_KEY              :   S3 API Key
             S3_SECRET           :   S3 Secret Key
@@ -30,16 +30,18 @@ def s3_upload(source_file, upload_dir=None):
             S3_UPLOAD_DIRECTORY :   Which S3 Directory.
     """
 
-    if upload_dir is None:
+    if directory:
+        upload_dir = "/".join(app.config["S3_UPLOAD_DIRECTORY", directory])
+    else:
         upload_dir = app.config["S3_UPLOAD_DIRECTORY"]
 
-    source_filename = source_file.data.filename
-
+    filename = secure_filename(source_file.filename)
+    headers = {"Content-Type": filename.content_type}
     # Connect to S3 and upload file.
     conn = boto.connect_s3(app.config["S3_KEY"], app.config["S3_SECRET"])
     b = conn.get_bucket(app.config["S3_BUCKET"])
 
-    key = b.new_key("/".join([upload_dir, source_filename]))
-    key.set_contents_from_string(source_file.data.read())
+    key = b.new_key("/".join([upload_dir, filename]))
+    key.set_contents_from_file(source_file.stream, headers=headers)
 
     return key.generate_url(0).split('?', 1)[0]


### PR DESCRIPTION
# Response file upload

This changes allow the upload of a file as part of a task's response. The file is saved into an s3 bucket and the url is stored in the task run info json string.

Depends on the python modules [Boto](https://github.com/boto/boto/) for s3 upload and [python-magic](https://github.com/ahupp/python-magic) for mime-type inference and validation.

## Upload file by specifying content
The first way to upload a file is by specifying the content as a string in the task.info json.
```javascript
task.info.myfile__upload_url = {
    filename: "myfile.txt",
    content: "this is an example"
}
```
Note that the field name must have `__upload_url` as suffix.

## Upload file using `FormData`
Can use the FormData api to upload files. Append blobs to a formData object

```javascript
var info = {
    "project_id": task.project_id,
    "task_id": task.id,
    "info": task.answer
};
var taskrun = new FormData();
taskrun.append("request_json", JSON.stringify(info))
        
var file = new Blob(["aaaaa"], {type: "text/plain"});
taskrun.append("myfile__upload_url", file, "a.txt");

$.ajax({
    type: 'POST',
    url: url + 'api/taskrun',
    contentType: false,
    processData: false,
    data: taskrun
});
```
Note in this case, the plain text answers are sent as a json string in the field `request_json` in the `FormData` object. The names of the file fields should still end in `__upload_url`
