### PR TITLE
Fix local csv bulk upload

### DIFF
--- a/pybossa/pybossa/forms/forms.py
+++ b/pybossa/pybossa/forms/forms.py
@@ -32,6 +32,7 @@ import re
 from wtforms.validators import ValidationError
 from flask import request
 from werkzeug.utils import secure_filename
+import tempfile, os
 
 EMAIL_MAX_LENGTH = 254
 USER_NAME_MAX_LENGTH = 35
@@ -158,7 +159,6 @@ class _BulkTaskGDImportForm(Form):
     def get_import_data(self):
         return {'type': 'gdocs', 'googledocs_url': self.googledocs_url.data}
 
-
 class _BulkTaskLocalCSVImportForm(Form):
     form_name = TextField(label=None, widget=HiddenInput(), default='localcsv')
     _allowed_extensions = set(['csv'])                               
@@ -177,9 +177,15 @@ class _BulkTaskLocalCSVImportForm(Form):
                 return {'type': 'localcsv', 'csv_filename': None}
             if file and self._allowed_file(file.filename):
                 filename = secure_filename(file.filename)
-                return {'type': 'localcsv', 'csv_filename': file.filename}
+                tmpfile = tempfile.NamedTemporaryFile(delete=False)
+                try:
+                    tmpfile.file.write(file.stream.read())
+                    return {'type': 'localcsv', 'csv_filename': tmpfile.name}
+                except Exception as e:
+                    os.unlink(tmpfile.name)
+                    raise e    
         return {'type': 'localcsv', 'csv_filename': None}
-
+        
 
 class _BulkTaskEpiCollectPlusImportForm(Form):
     form_name = TextField(label=None, widget=HiddenInput(), default='epicollect')
@@ -222,7 +228,7 @@ class GenericBulkTaskImportForm(object):
               'epicollect': _BulkTaskEpiCollectPlusImportForm,
               'flickr': _BulkTaskFlickrImportForm,
               'dropbox': _BulkTaskDropboxImportForm,
-              'localcsv': _BulkTaskLocalCSVImportForm }
+              'localcsv': _BulkTaskLocalCSVImportForm}
 
     def __call__(self, form_name, *form_args, **form_kwargs):
         if form_name is None:

--- a/pybossa/pybossa/importers.py
+++ b/pybossa/pybossa/importers.py
@@ -23,8 +23,8 @@ from StringIO import StringIO
 from flask.ext.babel import gettext
 from pybossa.util import unicode_csv_reader
 from flask import request
+from werkzeug.datastructures import FileStorage
 import io
-
 
 class BulkImportException(Exception):
 
@@ -47,7 +47,7 @@ class _BulkTaskImport(object):
         """Return amount of tasks to be imported."""
         return len([task for task in self.tasks(**form_data)])
 
-
+        
 class _BulkTaskCSVImport(_BulkTaskImport):
 
     """Class to import CSV tasks in bulk."""
@@ -126,7 +126,6 @@ class _BulkTaskCSVImport(_BulkTaskImport):
         csvreader = unicode_csv_reader(csvcontent)
         return self._import_csv_tasks(csvreader)
 
-
 class _BulkTaskLocalCSVImport(_BulkTaskCSVImport):
 
     """Class to import CSV tasks in bulk from local file."""
@@ -137,23 +136,25 @@ class _BulkTaskLocalCSVImport(_BulkTaskCSVImport):
         """Get data."""
         return form_data['csv_filename']
         
-    def _get_csv_data_from_request(self, csv_filename):        
+    def _get_csv_data_from_request(self, csv_filename):
         if csv_filename is None:
             msg = ("Not a valid csv file for import")
             raise BulkImportException(gettext(msg), 'error')
 
-        if (('text/plain' not in request.headers['content-type']) and
-                ('text/csv' not in request.headers['content-type']) and
-                ('multipart/form-data' not in request.headers['content-type'])):
-            msg = gettext("Oops! That file doesn't look like the right file.")
-            raise BulkImportException(msg, 'error')
+        file = FileStorage(open(csv_filename, 'r'))
+        if file is None:
+            if (('text/plain' not in request.headers['content-type']) and
+                    ('text/csv' not in request.headers['content-type']) and
+                    ('multipart/form-data' not in request.headers['content-type'])):
+                msg = gettext("Oops! That file doesn't look like the right file.")
+                raise BulkImportException(msg, 'error')
 
-        request.encoding = 'utf-8'
-        file = request.files['file']
-        if file is None or file.stream is None:
-            msg = ("Not a valid csv file for import")
-            raise BulkImportException(gettext(msg), 'error')
-        
+            request.encoding = 'utf-8'
+            file = request.files['file']
+            if file is None or file.stream is None:
+                msg = ("Not a valid csv file for import")
+                raise BulkImportException(gettext(msg), 'error') 
+            
         file.stream.seek(0)
         csvcontent = io.StringIO(file.stream.read().decode("UTF8"))
         csvreader = unicode_csv_reader(csvcontent)
@@ -163,8 +164,8 @@ class _BulkTaskLocalCSVImport(_BulkTaskCSVImport):
         """Get tasks from a given URL."""
         csv_filename = self._get_data(**form_data)
         return self._get_csv_data_from_request(csv_filename)
-
-
+                
+        
 class _BulkTaskGDImport(_BulkTaskCSVImport):
 
     """Class to import tasks from Google Drive in bulk."""
@@ -181,6 +182,7 @@ class _BulkTaskGDImport(_BulkTaskCSVImport):
         else:
             return ''.join([form_data['googledocs_url'].split('edit')[0],
                             'export?format=csv'])
+
 
 
 class _BulkTaskEpiCollectPlusImport(_BulkTaskImport):


### PR DESCRIPTION
for tasks > 200, import is triggered by background job rq-worker that doesn't have request.files object from browser/ui. hence load file object from tempfile location stored under csv_filename from browser when calculating number of tasks to export(before import is handed over to background job)